### PR TITLE
Talbot support setProjectLocation endpoint by adding appropriate tests

### DIFF
--- a/core/src/test/groovy/org/justserve/GraphQLClientSpec.groovy
+++ b/core/src/test/groovy/org/justserve/GraphQLClientSpec.groovy
@@ -2,9 +2,14 @@ package org.justserve
 
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import jakarta.inject.Inject
+import net.datafaker.Faker
 import org.justserve.client.GraphQLClient
 import org.justserve.model.EventType
+import org.justserve.model.GraphQLCreateProjectData
 import org.justserve.model.GraphQLCreateProjectVariables
+import org.justserve.model.GraphQLResponse
+import org.justserve.model.GraphQLSetProjectLocationVariables
+import org.justserve.model.GraphQLSetProjectLocationVariablesLocationData
 import org.justserve.model.ProjectLocationType
 import spock.lang.Shared
 import spock.lang.Specification
@@ -16,6 +21,18 @@ class GraphQLClientSpec extends Specification {
     @Inject
     GraphQLClient client
 
+    @Shared
+    GraphQLResponse<GraphQLCreateProjectData> projectData
+
+    def setupSpec() {
+        GraphQLCreateProjectVariables createProjectArgs = new GraphQLCreateProjectVariables()
+                .setEventType(EventType.DTL)
+                .setLocationType(ProjectLocationType.SINGLE_LOCATION)
+                .setTitle("this is my title")
+                .setRedirect("https://google.com")
+        projectData = client.createProject(createProjectArgs)
+    }
+
     void "can create Project with EventType: #eventType, LocationType: #locationType, and Redirect: #redirect"(EventType eventType, ProjectLocationType locationType, String redirect) {
         given:
         GraphQLCreateProjectVariables args = new GraphQLCreateProjectVariables()
@@ -26,11 +43,45 @@ class GraphQLClientSpec extends Specification {
 
         when:
         client.createProject(args)
-
         then:
         noExceptionThrown()
 
         where:
         [eventType, locationType, redirect] << [EventType.values(), ProjectLocationType.values(), ["", null, "https://google.com"]].combinations()
+    }
+
+    void "can set project location using Project Id: #projectId, Location: #location, Location Data: #locationData"(UUID projectId, String location, GraphQLSetProjectLocationVariablesLocationData locationData) {
+        given:
+        GraphQLSetProjectLocationVariables addAttachmentArgs = new GraphQLSetProjectLocationVariables()
+                .setProjectId(projectId)
+                .setLocation(location)
+                .setLocationData(locationData)
+
+        when:
+
+        client.setProjectLocation(addAttachmentArgs)
+
+        then:
+        noExceptionThrown()
+
+        where:
+//        TODO: Replace hardcoded values to make this a bit more dynamic
+        [projectId, location, locationData] << [projectData.data.createProject.id, ["20 West 6th Street, Tempe, Arizona, United States", null, ""], [null, new GraphQLSetProjectLocationVariablesLocationData()
+                .setAddress("20 West 6th Street")
+                .setAreaId("790052")
+                .setCcId("543306")
+                .setCity("Tempe")
+                .setCountry("United States")
+                .setCountryCode("us")
+                .setCounty("Maricopa County")
+                .setLocationDetails("")
+                .setLocationName("20 West 6th Street, Tempe, Arizona, United States")
+                .setLatitude(33.4245772)
+                .setLongitude(-111.9410241)
+                .setMissionId("2011050")
+                .setPostal("85281")
+                .setStakeId("504297")
+                .setState("Arizona")
+        ]].combinations()
     }
 }

--- a/core/src/test/resources/application-test.yaml
+++ b/core/src/test/resources/application-test.yaml
@@ -3,6 +3,8 @@ micronaut:
     services:
       justserve:
         url: https://stage.justserve.org
+justserve:
+  token: ${:i-need-to-be-defined}
 logger:
   levels:
     io.micronaut.http.client: DEBUG


### PR DESCRIPTION
Added a setupSpec to make important project data related to the specific project being edited available for all following tests. And added baseline tests for the setProjectLocation endpoint. #76 