### PR TITLE
test: test searchOrganization() query parser

### DIFF
--- a/core/src/main/resources/schema.yml
+++ b/core/src/main/resources/schema.yml
@@ -2111,8 +2111,12 @@ components:
       type: object
       properties:
         searchTerm:
+          minLength: 3
+          maxLength: 100
+          description: must not be null, and must be at least three characters long to avoid an exception
           type: string
         includeAll:
+          description: must not be null
           type: boolean
     GraphQLSetProjectLocationRequest:
       type: object

--- a/core/src/test/groovy/org/justserve/GraphQLClientSpec.groovy
+++ b/core/src/test/groovy/org/justserve/GraphQLClientSpec.groovy
@@ -367,4 +367,23 @@ class GraphQLClientSpec extends Specification {
         noExceptionThrown()
         !response.hasErrors()
     }
+
+    def "test searchOrganization parses the input correctly"(String searchTerm, Boolean includesAll) {
+        given:
+
+        GraphQLSearchOrganizationVariables inputData = new GraphQLSearchOrganizationVariables()
+                .setSearchTerm(searchTerm)
+                .setIncludeAll(includesAll)
+
+        when:
+        GraphQLResponse<GraphQLSearchOrganizationData> response = client.searchOrganization(inputData)
+
+        then:
+        noExceptionThrown()
+        !response.hasErrors()
+
+        where:
+        [includesAll, searchTerm] << [[true, false], ["the"]].combinations()
+
+    }
 }

--- a/core/src/test/groovy/org/justserve/JustServeSpec.groovy
+++ b/core/src/test/groovy/org/justserve/JustServeSpec.groovy
@@ -78,6 +78,7 @@ class JustServeSpec extends Specification {
                 .builder()
                 .environments(Environment.CLI, Environment.TEST)
                 .environmentVariableExcludes("JUSTSERVE_TOKEN")
+                .properties(["justserve.token": ""])
                 .build()
                 .start()
         noAuthUserClient = noAuthCtx.getBean(UserClient)

--- a/core/src/test/groovy/org/justserve/JustServeSpec.groovy
+++ b/core/src/test/groovy/org/justserve/JustServeSpec.groovy
@@ -71,9 +71,7 @@ class JustServeSpec extends Specification {
         // }
         ctx = ApplicationContext.builder()
                 .environments(Environment.CLI, Environment.TEST)
-                .properties([
-                        "justserve.token": System.getenv("TEST_TOKEN")
-                ])
+                .properties(["justserve.token": System.getenv("TEST_TOKEN")])
                 .build()
                 .start()
         noAuthCtx = ApplicationContext
@@ -107,14 +105,13 @@ class JustServeSpec extends Specification {
     HttpResponse<CreateUser200Response> createUser(UserClient client = noAuthUserClient) {
         HttpResponse<CreateUser200Response> response = null
         def tries = 0
-        while ((null == response || HttpStatus.OK != response.status()) && tries < 5) {
+        while ((null == response || ![HttpStatus.OK, HttpStatus.CREATED].contains(response.status())) && tries < 5) {
             try {
                 // A new user is generated on each loop iteration to avoid collisions
                 response = createUserFromFaker(client, new TestUser(new Faker(Locale.of("en-us"))))
             } catch (HttpClientResponseException ignored) {
-                tries++
-                // This user likely already exists, so we'll loop and try a new one.
             }
+            tries++
         }
         if (null == response) {
             throw new IllegalStateException("failed to create a test user after five attempts")
@@ -161,7 +158,7 @@ class JustServeSpec extends Specification {
                 .setContactPhone(faker.phoneNumber().phoneNumber())
                 .setDescription(faker.zelda().game())
                 .setLocationString(knownWorkingLocation)
-                .setLogo(getUploadedImageFileName())
+                .setLogo(null)
                 .setName(faker.zelda().character())
                 .set_public(null)
                 .setUrl(getUniqueSlug())
@@ -196,9 +193,7 @@ class JustServeSpec extends Specification {
      * @return The file name of the uploaded image.
      */
     String getUploadedImageFileName() {
-        HttpResponse<ImageUploadResponse> profileImage = authImageClient.uploadImage(
-                new ImageUploadRequest(faker.image().base64JPG().split(",")[1], 256, 256, false, 0, 0)
-        )
+        HttpResponse<ImageUploadResponse> profileImage = authImageClient.uploadImage(new ImageUploadRequest(faker.image().base64JPG().split(",")[1], 256, 256, false, 0, 0))
         return profileImage.body().displayFileName
     }
 
@@ -209,7 +204,7 @@ class JustServeSpec extends Specification {
     String getUniqueSlug() {
         String urlSlug = null
         while (null == urlSlug) {
-            def potentialSlug = faker.word().noun()
+            def potentialSlug = faker.word().noun() + System.currentTimeMillis()
             def response = authDynamicRoutingClient.getOrgIdFromSlug(potentialSlug)
             if (response.status() == HttpStatus.NOT_FOUND) {
                 urlSlug = potentialSlug


### PR DESCRIPTION
Since searchOrganization() has no conditional parameters that only need to be used if other parameters are not used it does not require any enums to be written for it. Therefore I simply added basic tests for the query parser searchOrganizations(). 

A few things to note about this is that I chose not to find out why the min and max length headers do not actually prevent a string with too few characters from being entered and sent in the query.

Additionally adding specifications into the schema that the two parameters should not be left as null fails to be included in the compiled code. 

For now I have added documentation to those two fields, so when the backend throws an exception for either of these two failures if a user looks at the documentation they can find out why.

This PR would resolve #83